### PR TITLE
Removing un-needed argument

### DIFF
--- a/lib/dot_example.rb
+++ b/lib/dot_example.rb
@@ -7,7 +7,7 @@ require_relative "dot_example/pre_commit_hook"
 require_relative "dot_example/post_checkout_hook"
 
 module DotExample
-  def self.add_pre_commit_hook(dot_env_dot_example)
+  def self.add_pre_commit_hook
     pre_commit_hook = PreCommitHook.new
     pre_commit_hook.write!
   end


### PR DESCRIPTION
Hi there. Thanks a lot for making this gem. Really cool idea.

I ran into an issue setting up the library: 

```
docker-compose run web dot_example setup --trace
/usr/local/bundle/gems/dot_example-1.0.0/lib/dot_example.rb:10:in `add_pre_commit_hook': wrong number of arguments (given 0, expected 1) (ArgumentError)
    from /usr/local/bundle/gems/dot_example-1.0.0/bin/dot_example:20:in `block (2 levels) in <top (required)>'
    from /usr/local/bundle/gems/commander-4.4.0/lib/commander/command.rb:178:in `call'
    from /usr/local/bundle/gems/commander-4.4.0/lib/commander/command.rb:153:in `run'
    from /usr/local/bundle/gems/commander-4.4.0/lib/commander/runner.rb:444:in `run_active_command'
    from /usr/local/bundle/gems/commander-4.4.0/lib/commander/runner.rb:68:in `run!'
    from /usr/local/bundle/gems/commander-4.4.0/lib/commander/delegates.rb:15:in `run!'
    from /usr/local/bundle/gems/commander-4.4.0/lib/commander/import.rb:5:in `block in <top (required)>'
```

I think there's just a no-longer-needed argument in there. Seemed to solve the problem for me anyway 😉. 

Thanks!! 
